### PR TITLE
Fix leapuvc.py for newer OpenCV versions

### DIFF
--- a/Python/leapuvc.py
+++ b/Python/leapuvc.py
@@ -18,7 +18,7 @@ class leapImageThread(threading.Thread):
         self.cam = cv2.VideoCapture(self.source)
         self.cam.set(cv2.CAP_PROP_FRAME_WIDTH, resolution[0])
         self.cam.set(cv2.CAP_PROP_FRAME_HEIGHT, resolution[1])
-        self.cam.set(cv2.CAP_PROP_CONVERT_RGB, False) # Does not work reliably in DirectShow :(
+        self.cam.set(cv2.CAP_PROP_CONVERT_RGB, 0.0) # Does not work reliably in DirectShow :(
         self.resolution = (int(self.cam.get(cv2.CAP_PROP_FRAME_WIDTH)), 
                            int(self.cam.get(cv2.CAP_PROP_FRAME_HEIGHT)))
         self.frame = None


### PR DESCRIPTION
Newer OpenCV versions expect a float instead of a bool for cv2.CAP_PROP_CONVERT_RGB